### PR TITLE
Generate menu generically, show checkmarks

### DIFF
--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -32,6 +32,8 @@ namespace CKAN
         public int SortByColumnIndex = 2;
         public bool SortDescending = false;
 
+        public bool[] VisibleColumns = { true, true, true, true, true, true, true, true, true };
+
         private string path = "";
 
         /// <summary>

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -84,6 +84,7 @@
             this.DownloadCount = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Description = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ModListContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.ModListHeaderContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.reinstallToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.downloadContentsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ModInfoTabControl = new CKAN.MainModInfo();
@@ -148,6 +149,7 @@
             this.splitContainer1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.ModList)).BeginInit();
             this.ModListContextMenuStrip.SuspendLayout();
+            this.ModListHeaderContextMenuStrip.SuspendLayout();
             this.statusStrip1.SuspendLayout();
             this.MainTabControl.SuspendLayout();
             this.ManageModsTabPage.SuspendLayout();
@@ -543,7 +545,6 @@
             this.InstallDate,
             this.DownloadCount,
             this.Description});
-            this.ModList.ContextMenuStrip = this.ModListContextMenuStrip;
             this.ModList.Location = new System.Drawing.Point(0, 111);
             this.ModList.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.ModList.MultiSelect = false;
@@ -630,7 +631,7 @@
             this.SizeCol.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             // 
             // InstallDate
-            //
+            // 
             this.InstallDate.HeaderText = "Install Date";
             this.InstallDate.Name = "InstallDate";
             this.InstallDate.ReadOnly = true;
@@ -638,7 +639,7 @@
             this.InstallDate.Width = 140;
             //
             // DownloadCount
-            //
+            // 
             this.DownloadCount.HeaderText = "Downloads";
             this.DownloadCount.Name = "DownloadCount";
             this.DownloadCount.ReadOnly = true;
@@ -675,6 +676,12 @@
             this.downloadContentsToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
             this.downloadContentsToolStripMenuItem.Text = "Download Contents";
             this.downloadContentsToolStripMenuItem.Click += new System.EventHandler(this.downloadContentsToolStripMenuItem_Click);
+            // 
+            // ModListHeaderContextMenuStrip
+            // 
+            this.ModListHeaderContextMenuStrip.Name = "ModListHeaderContextMenuStrip";
+            this.ModListHeaderContextMenuStrip.AutoSize = true;
+            this.ModListHeaderContextMenuStrip.ItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(ModListHeaderContextMenuStrip_ItemClicked);
             // 
             // ModInfoTabControl
             // 
@@ -1282,6 +1289,7 @@
             this.splitContainer1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.ModList)).EndInit();
             this.ModListContextMenuStrip.ResumeLayout(false);
+            this.ModListHeaderContextMenuStrip.ResumeLayout(false);
             this.statusStrip1.ResumeLayout(false);
             this.statusStrip1.PerformLayout();
             this.MainTabControl.ResumeLayout(false);
@@ -1358,6 +1366,7 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn DownloadCount;
         private System.Windows.Forms.DataGridViewTextBoxColumn Description;
         private System.Windows.Forms.ContextMenuStrip ModListContextMenuStrip;
+        private System.Windows.Forms.ContextMenuStrip ModListHeaderContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem reinstallToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem downloadContentsToolStripMenuItem;
         private CKAN.MainModInfo ModInfoTabControl;

--- a/GUI/Main.Designer.cs
+++ b/GUI/Main.Designer.cs
@@ -681,6 +681,7 @@
             // 
             this.ModListHeaderContextMenuStrip.Name = "ModListHeaderContextMenuStrip";
             this.ModListHeaderContextMenuStrip.AutoSize = true;
+            this.ModListHeaderContextMenuStrip.ShowCheckMargin = true;
             this.ModListHeaderContextMenuStrip.ItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(ModListHeaderContextMenuStrip_ItemClicked);
             // 
             // ModInfoTabControl

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -174,6 +174,7 @@ namespace CKAN
                 FilterToolButton.DropDown.Renderer = new FlatToolStripRenderer();
                 minimizedContextMenuStrip.Renderer = new FlatToolStripRenderer();
                 ModListContextMenuStrip.Renderer = new FlatToolStripRenderer();
+                ModListHeaderContextMenuStrip.Renderer = new FlatToolStripRenderer();
             }
 
             // Initialize all user interaction dialogs.
@@ -755,20 +756,38 @@ namespace CKAN
             Filter(GUIModFilter.All);
         }
 
+        /// <summary>
+        /// Called when the modlist filter (all, compatible, incompatible...) is changed.
+        /// </summary>
+        /// <param name="filter">Filter.</param>
         private void Filter(GUIModFilter filter)
         {
+            // Triggers mainModList.ModFiltersUpdated()
             mainModList.ModFilter = filter;
+
+            // Ask the configuration which columns to show.
+            // Start with the third column, because the first one is alwas shown
+            // and the 2nd/3rd are handled by UpdateModsList().
+            for (int i = 3; i < ModList.Columns.Count; i++)
+            {
+                ModList.Columns[i].Visible = configuration.VisibleColumns[i-3];
+            }
 
             switch (filter)
             {
-                case GUIModFilter.All:                      FilterToolButton.Text = "Filter (All)";          break;
+                // Some columns really do / don't make sense to be visible on certain filter settings.
+                // Hide / Show them, without writing to config, so once the user changes tab again,
+                // they are shown / hidden again, as before.
+                case GUIModFilter.All:                      FilterToolButton.Text = "Filter (All)";           break;
                 case GUIModFilter.Incompatible:             FilterToolButton.Text = "Filter (Incompatible)";  break;
                 case GUIModFilter.Installed:                FilterToolButton.Text = "Filter (Installed)";     break;
                 case GUIModFilter.InstalledUpdateAvailable: FilterToolButton.Text = "Filter (Upgradeable)";   break;
                 case GUIModFilter.Replaceable:              FilterToolButton.Text = "Filter (Replaceable)";   break;
                 case GUIModFilter.Cached:                   FilterToolButton.Text = "Filter (Cached)";        break;
                 case GUIModFilter.NewInRepository:          FilterToolButton.Text = "Filter (New)";           break;
-                case GUIModFilter.NotInstalled:             FilterToolButton.Text = "Filter (Not installed)"; break;
+                case GUIModFilter.NotInstalled:             FilterToolButton.Text = "Filter (Not installed)";
+                                                            ModList.Columns[5].Visible = false;
+                                                            ModList.Columns[9].Visible = false;               break;
                 default:                                    FilterToolButton.Text = "Filter (Compatible)";    break;
             }
         }

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -397,7 +397,7 @@ namespace CKAN
 
             if (col != null)
             {
-                configuration.VisibleColumns[col.Index] = col.Visible = !clickedItem.Checked;
+                configuration.VisibleColumns[col.Index - 3] = col.Visible = !clickedItem.Checked;
                 if (col.Index == 0)
                 {
                     InstallAllCheckbox.Visible = col.Visible;


### PR DESCRIPTION
KSP-CKAN/CKAN#2690 is creating a context menu to show/hide mod list columns.

This pull request makes two changes:

1. The menu is auto-generated based on the columns, so it doesn't need to be manually updated when future columns are added
2. The menu items use checkmarks instead of a blue border to indicate they're selected:

![image](https://user-images.githubusercontent.com/1559108/53587957-579ff000-3b51-11e9-910c-611898803508.png)