### PR TITLE
Save/load column names instead of list of bools

### DIFF
--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -41,7 +41,7 @@ namespace CKAN
         /// </summary>
         /// <param name="name">Name property of the column</param>
         /// <param name="vis">true if visible, false if hidden</param>
-        public void SetColumnVisible(string name, bool vis)
+        public void SetColumnVisibility(string name, bool vis)
         {
             if (vis)
             {

--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -34,7 +34,7 @@ namespace CKAN
         public bool SortDescending = false;
 
         [XmlArray, XmlArrayItem(ElementName = "ColumnName")]
-        public List<string> VisibleColumnNames = new List<string>();
+        public List<string> HiddenColumnNames = new List<string>();
 
         /// <summary>
         /// Set whether a column name is in the visible list
@@ -43,13 +43,13 @@ namespace CKAN
         /// <param name="vis">true if visible, false if hidden</param>
         public void SetColumnVisible(string name, bool vis)
         {
-            if (!vis)
+            if (vis)
             {
-                VisibleColumnNames.RemoveAll(n => n == name);
+                HiddenColumnNames.RemoveAll(n => n == name);
             }
-            else if (!VisibleColumnNames.Contains(name))
+            else if (!HiddenColumnNames.Contains(name))
             {
-                VisibleColumnNames.Add(name);
+                HiddenColumnNames.Add(name);
             }
         }
 
@@ -120,21 +120,6 @@ namespace CKAN
                 try
                 {
                     configuration = (Configuration) serializer.Deserialize(stream);
-                    // Set default list of columns if missing
-                    if (configuration.VisibleColumnNames == null || configuration.VisibleColumnNames.Count < 1)
-                    {
-                        configuration.VisibleColumnNames = new List<string>() {
-                            "ModName",
-                            "Author",
-                            "InstalledVersion",
-                            "LatestVersion",
-                            "KSPCompatibility",
-                            "SizeCol",
-                            "InstallDate",
-                            "DownloadCount",
-                            "Description"
-                        };
-                    }
                 }
                 catch (System.Exception e)
                 {

--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -124,9 +124,6 @@ namespace CKAN
                     if (configuration.VisibleColumnNames == null || configuration.VisibleColumnNames.Count < 1)
                     {
                         configuration.VisibleColumnNames = new List<string>() {
-                            "Installed",
-                            "UpdateCol",
-                            "ReplaceCol",
                             "ModName",
                             "Author",
                             "InstalledVersion",

--- a/GUI/Configuration.cs
+++ b/GUI/Configuration.cs
@@ -1,6 +1,7 @@
 ﻿using System.Drawing;
 using System.IO;
 using System.Xml.Serialization;
+using System.Collections.Generic;
 
 namespace CKAN
 {
@@ -32,7 +33,25 @@ namespace CKAN
         public int SortByColumnIndex = 2;
         public bool SortDescending = false;
 
-        public bool[] VisibleColumns = { true, true, true, true, true, true, true, true, true };
+        [XmlArray, XmlArrayItem(ElementName = "ColumnName")]
+        public List<string> VisibleColumnNames = new List<string>();
+
+        /// <summary>
+        /// Set whether a column name is in the visible list
+        /// </summary>
+        /// <param name="name">Name property of the column</param>
+        /// <param name="vis">true if visible, false if hidden</param>
+        public void SetColumnVisible(string name, bool vis)
+        {
+            if (!vis)
+            {
+                VisibleColumnNames.RemoveAll(n => n == name);
+            }
+            else if (!VisibleColumnNames.Contains(name))
+            {
+                VisibleColumnNames.Add(name);
+            }
+        }
 
         private string path = "";
 
@@ -101,6 +120,24 @@ namespace CKAN
                 try
                 {
                     configuration = (Configuration) serializer.Deserialize(stream);
+                    // Set default list of columns if missing
+                    if (configuration.VisibleColumnNames == null || configuration.VisibleColumnNames.Count < 1)
+                    {
+                        configuration.VisibleColumnNames = new List<string>() {
+                            "Installed",
+                            "UpdateCol",
+                            "ReplaceCol",
+                            "ModName",
+                            "Author",
+                            "InstalledVersion",
+                            "LatestVersion",
+                            "KSPCompatibility",
+                            "SizeCol",
+                            "InstallDate",
+                            "DownloadCount",
+                            "Description"
+                        };
+                    }
                 }
                 catch (System.Exception e)
                 {

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -772,7 +772,7 @@ namespace CKAN
                 // and the 2nd/3rd are handled by UpdateModsList().
                 if (col.Index > 2)
                 {
-                    col.Visible = configuration.VisibleColumnNames.Contains(col.Name);
+                    col.Visible = !configuration.HiddenColumnNames.Contains(col.Name);
                 }
             }
 

--- a/GUI/Main.cs
+++ b/GUI/Main.cs
@@ -766,11 +766,14 @@ namespace CKAN
             mainModList.ModFilter = filter;
 
             // Ask the configuration which columns to show.
-            // Start with the third column, because the first one is alwas shown
-            // and the 2nd/3rd are handled by UpdateModsList().
-            for (int i = 3; i < ModList.Columns.Count; i++)
+            foreach (DataGridViewColumn col in ModList.Columns)
             {
-                ModList.Columns[i].Visible = configuration.VisibleColumns[i-3];
+                // Start with the third column, because the first one is always shown
+                // and the 2nd/3rd are handled by UpdateModsList().
+                if (col.Index > 2)
+                {
+                    col.Visible = configuration.VisibleColumnNames.Contains(col.Name);
+                }
             }
 
             switch (filter)

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -396,7 +396,7 @@ namespace CKAN
             if (col != null)
             {
                 col.Visible = !clickedItem.Checked;
-                configuration.SetColumnVisible(col.Name, !clickedItem.Checked);
+                configuration.SetColumnVisibility(col.Name, !clickedItem.Checked);
                 if (col.Index == 0)
                 {
                     InstallAllCheckbox.Visible = col.Visible;

--- a/GUI/MainModList.cs
+++ b/GUI/MainModList.cs
@@ -278,9 +278,7 @@ namespace CKAN
             // Write it to the configuration, else they are hidden agian after a filter change.
             // After the update / replacement, they are hidden again.
             ModList.Columns[1].Visible = has_any_updates;
-            configuration.VisibleColumns[1] = has_any_updates;
             ModList.Columns[2].Visible = has_any_replacements;
-            configuration.VisibleColumns[2] = has_any_replacements;
 
             AddLogMessage("Updating tray...");
             UpdateTrayInfo();
@@ -397,7 +395,8 @@ namespace CKAN
 
             if (col != null)
             {
-                configuration.VisibleColumns[col.Index - 3] = col.Visible = !clickedItem.Checked;
+                col.Visible = !clickedItem.Checked;
+                configuration.SetColumnVisible(col.Name, !clickedItem.Checked);
                 if (col.Index == 0)
                 {
                     InstallAllCheckbox.Visible = col.Visible;


### PR DESCRIPTION
KSP-CKAN/CKAN#2690 is creating a context menu to show/hide mod list columns.

Currently it saves and loads a list of bools to the GUI config file to track which columns are visible:

https://github.com/DasSkelett/CKAN/blob/c01947c004158a3a8734efdb7ab8724702965ad6/GUI/Configuration.cs#L35

This presents two problems:

1. It is not compatible with rearranging the order of the columns. If we ever want to add that in the future, this would have to be re-done, or another mechanism layered on top of it.
2. It is awkward if we want to add a new column in between two existing columns. The new column would have to be represented by a boolean value somewhere, and while the natural place for it is in the middle of the bool array, existing config files could not be loaded if it was done that way.

This pull request changes the configuration mechanism to save and load a list of strings representing the visible column names. This is flexible enough to accommodate reordering columns and adding new ones between old ones.