### PR TITLE
32 bit for verbose GUI (DasSkelett/CKAN#6)

### DIFF
--- a/macosx/CKAN
+++ b/macosx/CKAN
@@ -23,13 +23,16 @@ else
     # The exe is called ckan.exe
     ASSEMBLY=ckan.exe
 
-    # If we want to run the GUI, set mono to 32bit mode. If not, go 64bit.
-    if [ $# -eq 0 ] || [ $1 == "gui" ]
-    then
-        MONO_ARGS="--arch=32"
-    else
-        MONO_ARGS="--arch=64"
-    fi
+    MONO_ARGS="--arch=32"
+    for ARG in "$@"
+    do
+        # If we want to run the GUI, set mono to 32bit mode. If not, go 64bit.
+        if [[ ! $ARG =~ ^- && $ARG != gui ]]
+        then
+            MONO_ARGS="--arch=64"
+            break
+        fi
+    done
 
     # The script and ckan.exe are in the same folder, go there now
     MACOS_PATH="$(cd "$(dirname "$0")" && pwd)"


### PR DESCRIPTION
KSP-CKAN/CKAN#2893:

> This breaks commands like ckan --verbose (on macOS only, of course), which normally should run the GUI with verbose logging in the console. But I don't think a lot of people used this, and they can still add gui in the middle to make it work again, so ckan gui --verbose.

It's not a big problem, but I think we can solve it anyway. This checks the args to see if there's anything that doesn't start with a `-` other than `gui`.