### PR TITLE
Load cache info in background

### DIFF
--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -60,11 +60,6 @@ namespace CKAN
             UpdateRefreshRate();
 
             UpdateCacheInfo(config.DownloadCacheDir);
-            if (config.CacheSizeLimit.HasValue)
-            {
-                // Show setting in MB
-                CacheLimit.Text = (config.CacheSizeLimit.Value / 1024 / 1024).ToString();
-            }
         }
 
         private void UpdateRefreshRate()
@@ -116,7 +111,7 @@ namespace CKAN
             // Else display a blank field.
             LanguageSelectionComboBox.SelectedIndex = LanguageSelectionComboBox.FindStringExact(config.Language);
         }
-        
+
         private bool updatingCache = false;
 
         private void UpdateCacheInfo(string newPath)
@@ -136,6 +131,11 @@ namespace CKAN
                     Main.Instance.Manager.Cache.GetSizeInfo(out m_cacheFileCount, out m_cacheSize);
                     Util.Invoke(this, () =>
                     {
+                        if (config.CacheSizeLimit.HasValue)
+                        {
+                            // Show setting in MB
+                            CacheLimit.Text = (config.CacheSizeLimit.Value / 1024 / 1024).ToString();
+                        }
                         CachePath.Text = config.DownloadCacheDir;
                         CacheSummary.Text = string.Format(Properties.Resources.SettingsDialogSummmary, m_cacheFileCount, CkanModule.FmtSize(m_cacheSize));
                         CacheSummary.ForeColor   = SystemColors.ControlText;

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -116,13 +116,20 @@ namespace CKAN
             // Else display a blank field.
             LanguageSelectionComboBox.SelectedIndex = LanguageSelectionComboBox.FindStringExact(config.Language);
         }
+        
+        private bool updatingCache = false;
 
         private void UpdateCacheInfo(string newPath)
         {
             string failReason;
+            if (updatingCache)
+            {
+                return;
+            }
             if (newPath == config.DownloadCacheDir
                 || Main.Instance.Manager.TrySetupCache(newPath, out failReason))
             {
+                updatingCache = true;
                 Task.Factory.StartNew(() =>
                 {
                     // This might take a little while if the cache is big
@@ -136,6 +143,7 @@ namespace CKAN
                         ClearCacheButton.Enabled = (m_cacheSize > 0);
                         PurgeToLimitMenuItem.Enabled = (config.CacheSizeLimit.HasValue
                             && m_cacheSize > config.CacheSizeLimit.Value);
+                        updatingCache = false;
                     });
                 });
             }


### PR DESCRIPTION
KSP-CKAN/CKAN#3058 is making some big improvements to the performance of loading the settings window.

I'm still seeing a short delay because I have a 58.1 GB cache (on spinning platters). This PR puts the `Cache.GetSizeInfo` call into a background thread so the form can continue loading, then when it's done `Util.Invoke` takes us back to the GUI thread so we can update the UI controls.