### PR TITLE
Put unindexed mods in Ignored modpack group

### DIFF
--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -116,7 +116,7 @@ namespace CKAN
         /// This includes DLLs, which will have a version type of `DllVersion`.
         /// This includes Provides if set, which will have a version of `ProvidesVersion`.
         /// </summary>
-        Dictionary<string, ModuleVersion> Installed(bool include_provides = true);
+        Dictionary<string, ModuleVersion> Installed(bool withProvides = true, bool withDLLs = true);
 
         /// <summary>
         /// Returns the InstalledModule, or null if it is not installed.

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -904,20 +904,23 @@ namespace CKAN
         /// <summary>
         /// <see cref = "IRegistryQuerier.Installed" />
         /// </summary>
-        public Dictionary<string, ModuleVersion> Installed(bool withProvides = true)
+        public Dictionary<string, ModuleVersion> Installed(bool withProvides = true, bool withDLLs = true)
         {
             var installed = new Dictionary<string, ModuleVersion>();
 
-            // Index our DLLs, as much as we dislike them.
-            foreach (var dllinfo in installed_dlls)
+            if (withDLLs)
             {
-                installed[dllinfo.Key] = new UnmanagedModuleVersion(null);
+                // Index our DLLs, as much as we dislike them.
+                foreach (var dllinfo in installed_dlls)
+                {
+                    installed[dllinfo.Key] = new UnmanagedModuleVersion(null);
+                }
             }
 
             // Index our provides list, so users can see virtual packages
             if (withProvides)
             {
-                foreach (var provided in Provided())
+                foreach (var provided in ProvidedByInstalled())
                 {
                     installed[provided.Key] = provided.Value;
                 }
@@ -948,14 +951,16 @@ namespace CKAN
         }
 
         /// <summary>
-        /// Returns a dictionary of provided (virtual) modules, and a
-        /// ProvidesVersion indicating what provides them.
+        /// Find modules provided by currently installed modules
         /// </summary>
-
-        // TODO: In the future it would be nice to cache this list, and mark it for rebuild
-        // if our installed modules change.
-        internal Dictionary<string, ProvidesModuleVersion> Provided()
+        /// <returns>
+        /// Dictionary of provided (virtual) modules and a
+        /// ProvidesVersion indicating what provides them
+        /// </returns>
+        internal Dictionary<string, ProvidesModuleVersion> ProvidedByInstalled()
         {
+            // TODO: In the future it would be nice to cache this list, and mark it for rebuild
+            // if our installed modules change.
             var installed = new Dictionary<string, ProvidesModuleVersion>();
 
             foreach (var modinfo in installed_modules)
@@ -1001,7 +1006,7 @@ namespace CKAN
             // withProvides is false.
             if (!with_provides) return null;
 
-            var provided = Provided();
+            var provided = ProvidedByInstalled();
 
             ProvidesModuleVersion version;
             return provided.TryGetValue(modIdentifier, out version) ? version : null;

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -449,8 +449,19 @@ namespace CKAN
                 download_content_type = "application/zip",
             };
 
-            List<RelationshipDescriptor> mods = registry.Installed()
-                .Where(mod => !(mod.Value is ProvidesModuleVersion || mod.Value is UnmanagedModuleVersion))
+            List<RelationshipDescriptor> mods = registry.Installed(false, false)
+                .Where(kvp => {
+                    // Skip unavailable modules (custom .ckan files)
+                    try
+                    {
+                        var avail = registry.LatestAvailable(kvp.Key, null, null);
+                        return true;
+                    }
+                    catch
+                    {
+                        return false;
+                    }
+                })
                 .Select(kvp => (RelationshipDescriptor) new ModuleRelationshipDescriptor()
                     {
                         name    = kvp.Key,

--- a/GUI/Controls/EditModpack.cs
+++ b/GUI/Controls/EditModpack.cs
@@ -90,6 +90,20 @@ namespace CKAN
             }
 
             ignored.Clear();
+            // Find installed modules that aren't in the module's relationships
+            ignored.AddRange(registry.Installed(false, false)
+                .Where(kvp => {
+                    var ids = new string[] { kvp.Key };
+                    return !module.depends.Any(rel => rel.ContainsAny(ids))
+                        && !module.recommends.Any(rel => rel.ContainsAny(ids))
+                        && !module.suggests.Any(rel => rel.ContainsAny(ids));
+                })
+                .Select(kvp => (RelationshipDescriptor) new ModuleRelationshipDescriptor()
+                    {
+                        name    = kvp.Key,
+                        version = kvp.Value,
+                    })
+            );
             RelationshipsListView.Items.Clear();
             AddGroup(module.depends,    DependsGroup,         registry);
             AddGroup(module.recommends, RecommendationsGroup, registry);

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -521,16 +521,6 @@ namespace CKAN
                         continue;
                     }
 
-                    // Don't add metapacakges to the registry
-                    if (!module.IsMetapackage)
-                    {
-                        // Remove this version of the module in the registry, if it exists.
-                        registry_manager.registry.RemoveAvailable(module);
-
-                        // Sneakily add our version in...
-                        registry_manager.registry.AddAvailable(module);
-                    }
-
                     if (module.IsDLC)
                     {
                         currentUser.RaiseError(Properties.Resources.MainCantInstallDLC, module);


### PR DESCRIPTION
## Background

In KSP-CKAN/CKAN#3139 we are fixing a problem with how the export modpack control retrieves mod descriptions (it threw exceptions for mods that aren't indexed, such as custom .ckan files created by the user).

This brings up a question I hadn't though of: Does it even make sense to include such mods in an exported modpack? Other users will almost certainly be unable to install them. It's possible to imagine situations where you might want that, but more often I think it'd be unintentional.

## Changes

- Non-indexed mods are now left out of the return value of `RegistryManager.GenerateModpack`, so now as far as Core is concerned, modpacks should consist only of indexed mods
- The modpack editor control now adds installed non-indexed mods to the Ignored list by default. The user can move them to another group if desired.
- Now custom modules installed from .ckan files will no longer be added to the list of available modules in the registry (see code review comments for details)